### PR TITLE
Update spark.rst doc

### DIFF
--- a/source/api/spark.rst
+++ b/source/api/spark.rst
@@ -268,4 +268,4 @@ And then run the tests like this:
 
 .. code-block:: shell
 
-    LD_LIBRARY_PATH=qdb/clang+llvm-5.0.0-x86_64-apple-darwin/lib/ sbt test
+    DYLD_LIBRARY_PATH=qdb/clang+llvm-5.0.0-x86_64-apple-darwin/lib/ sbt test


### PR DESCRIPTION
the common *nix `LD_LIBRARY_PATH` variable becomes `DYLD_LIBRARY_PATH` on macos